### PR TITLE
Httpx and Pydantic V2 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest, ubuntu-latest, macos-latest]
     env:
       OS: ${{ matrix.os }}
@@ -81,7 +81,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ["3.12"]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.9, 3.10, 3.11, 3.12]
         os: [windows-latest, ubuntu-latest, macos-latest]
     env:
       OS: ${{ matrix.os }}
@@ -102,3 +102,4 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+

--- a/rpcpy/application.py
+++ b/rpcpy/application.py
@@ -35,6 +35,7 @@ from rpcpy.openapi import TEMPLATE as OPENAPI_TEMPLATE
 from rpcpy.openapi import (
     ValidationError,
     create_model,
+    create_root_model,
     is_typed_dict_type,
     parse_typed_dict,
     set_type_model,
@@ -162,9 +163,9 @@ class RPC(metaclass=RPCMeta):
                 elif return_annotation is None:
                     resp_model = create_model(callback.__name__ + "-return")
                 else:
-                    resp_model = create_model(
-                        callback.__name__ + "-return",
-                        __root__=(return_annotation, ...),
+                    resp_model = create_root_model(
+                        model_name=callback.__name__ + "-return",
+                        return_annotation=return_annotation,
                     )
                 _schema = copy.deepcopy(resp_model.schema())
                 definitions.update(_schema.pop("definitions", {}))

--- a/rpcpy/client.py
+++ b/rpcpy/client.py
@@ -213,7 +213,7 @@ class ServerSentEventsParser:
         self.message: ServerSentEvent = {}
 
     def feed(self, line: str) -> ServerSentEvent | None:
-        if line == "\n":  # event split line
+        if not line or line == "\n":  # event split line
             event = self.message
             self.message = {}
             return event

--- a/rpcpy/openapi.py
+++ b/rpcpy/openapi.py
@@ -19,6 +19,9 @@ Callable = typing.TypeVar("Callable", bound=typing.Callable)
 try:
     from pydantic import BaseModel, ValidationError, create_model
     from pydantic import validate_arguments as pydantic_validate_arguments
+    from pydantic import VERSION as PYDANTIC_VERSION
+
+    IS_PYDANTIC_V2 = int(PYDANTIC_VERSION.split(".")[0]) >= 2
 
     # visit this issue
     # https://github.com/samuelcolvin/pydantic/issues/1205
@@ -41,6 +44,8 @@ try:
 
 except ImportError:
 
+    IS_PYDANTIC_V2 = False
+
     def create_model(*args, **kwargs):  # type: ignore
         raise NotImplementedError("Need install `pydantic` from pypi.")
 
@@ -54,6 +59,10 @@ except ImportError:
 
     if typing.TYPE_CHECKING:
         from pydantic import BaseModel
+        from pydantic import VERSION as PYDANTIC_VERSION
+
+if IS_PYDANTIC_V2:
+    from pydantic import RootModel
 
 
 def set_type_model(func: Callable) -> Callable:
@@ -109,6 +118,24 @@ def parse_typed_dict(typed_dict) -> typing.Type[BaseModel]:
             annotations[name] = (field, default_value)
 
     return create_model(typed_dict.__name__, **annotations)  # type: ignore
+
+
+def create_root_model(model_name: str, return_annotation: type) -> typing.Type[BaseModel]:
+    """
+    Create a Pydantic model with a single root field for the return type.
+
+    This function handles both Pydantic v1 and v2 styles of model creation.
+    """
+    if IS_PYDANTIC_V2:
+        # Dynamically create a subclass of RootModel
+        return type(
+            model_name,
+            (RootModel,),
+            {"__annotations__": {"root": return_annotation}},
+        )
+    else:
+        # Pydantic v1 style using create_model with __root__
+        return create_model(model_name, __root__=(return_annotation, ...))
 
 
 TEMPLATE = """<!DOCTYPE html>

--- a/rpcpy/openapi.py
+++ b/rpcpy/openapi.py
@@ -17,9 +17,9 @@ __all__ = [
 Callable = typing.TypeVar("Callable", bound=typing.Callable)
 
 try:
+    from pydantic import VERSION as PYDANTIC_VERSION
     from pydantic import BaseModel, ValidationError, create_model
     from pydantic import validate_arguments as pydantic_validate_arguments
-    from pydantic import VERSION as PYDANTIC_VERSION
 
     IS_PYDANTIC_V2 = int(PYDANTIC_VERSION.split(".")[0]) >= 2
 
@@ -58,8 +58,8 @@ except ImportError:
         """
 
     if typing.TYPE_CHECKING:
-        from pydantic import BaseModel
         from pydantic import VERSION as PYDANTIC_VERSION
+        from pydantic import BaseModel
 
 if IS_PYDANTIC_V2:
     from pydantic import RootModel

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -25,7 +25,6 @@ def wsgi_app():
     @app.register
     def yield_data(max_num: int) -> Generator[int, None, None]:
         for i in range(max_num):
-            time.sleep(1)
             yield i
 
     @app.register
@@ -55,7 +54,6 @@ def asgi_app():
     @app.register
     async def yield_data(max_num: int) -> AsyncGenerator[int, None]:
         for i in range(max_num):
-            await asyncio.sleep(1)
             yield i
 
     @app.register

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from typing import AsyncGenerator, Generator
 
 import httpx

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 from typing import AsyncGenerator, Generator
 
 import httpx
@@ -88,8 +87,7 @@ def async_client(asgi_app):
 
 def test_sync_client(sync_client):
     @sync_client.remote_call
-    def sayhi(name: str) -> str:
-        ...
+    def sayhi(name: str) -> str: ...
 
     assert sayhi("rpc.py") == "hi rpc.py"
 
@@ -99,8 +97,7 @@ def test_sync_client(sync_client):
     ):
 
         @sync_client.remote_call
-        async def sayhi(name: str) -> str:
-            ...
+        async def sayhi(name: str) -> str: ...
 
     @sync_client.remote_call
     def yield_data(max_num: int):
@@ -112,8 +109,7 @@ def test_sync_client(sync_client):
         index += 1
 
     @sync_client.remote_call
-    def exception() -> str:
-        ...
+    def exception() -> str: ...
 
     with pytest.raises(RemoteCallError, match="ValueError: Message"):
         exception()
@@ -130,8 +126,7 @@ def test_sync_client(sync_client):
 @pytest.mark.asyncio
 async def test_async_client(async_client):
     @async_client.remote_call
-    async def sayhi(name: str) -> str:
-        ...
+    async def sayhi(name: str) -> str: ...
 
     assert await sayhi("rpc.py") == "hi rpc.py"
 
@@ -141,8 +136,7 @@ async def test_async_client(async_client):
     ):
 
         @async_client.remote_call
-        def sayhi(name: str) -> str:
-            ...
+        def sayhi(name: str) -> str: ...
 
     @async_client.remote_call
     async def yield_data(max_num: int):
@@ -154,8 +148,7 @@ async def test_async_client(async_client):
         index += 1
 
     @async_client.remote_call
-    async def exception() -> str:
-        ...
+    async def exception() -> str: ...
 
     with pytest.raises(RemoteCallError, match="ValueError: Message"):
         await exception()
@@ -171,8 +164,7 @@ async def test_async_client(async_client):
 
 def test_none(sync_client):
     @sync_client.remote_call
-    def none() -> None:
-        ...
+    def none() -> None: ...
 
     assert none() is None
 
@@ -183,8 +175,7 @@ def test_none(sync_client):
 @pytest.mark.asyncio
 async def test_async_none(async_client):
     @async_client.remote_call
-    async def none() -> None:
-        ...
+    async def none() -> None: ...
 
     assert await none() is None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from typing import AsyncGenerator, Generator
 
 import httpx
@@ -87,7 +88,8 @@ def async_client(asgi_app):
 
 def test_sync_client(sync_client):
     @sync_client.remote_call
-    def sayhi(name: str) -> str: ...
+    def sayhi(name: str) -> str:
+        ...
 
     assert sayhi("rpc.py") == "hi rpc.py"
 
@@ -97,7 +99,8 @@ def test_sync_client(sync_client):
     ):
 
         @sync_client.remote_call
-        async def sayhi(name: str) -> str: ...
+        async def sayhi(name: str) -> str:
+            ...
 
     @sync_client.remote_call
     def yield_data(max_num: int):
@@ -109,7 +112,8 @@ def test_sync_client(sync_client):
         index += 1
 
     @sync_client.remote_call
-    def exception() -> str: ...
+    def exception() -> str:
+        ...
 
     with pytest.raises(RemoteCallError, match="ValueError: Message"):
         exception()
@@ -126,7 +130,8 @@ def test_sync_client(sync_client):
 @pytest.mark.asyncio
 async def test_async_client(async_client):
     @async_client.remote_call
-    async def sayhi(name: str) -> str: ...
+    async def sayhi(name: str) -> str:
+        ...
 
     assert await sayhi("rpc.py") == "hi rpc.py"
 
@@ -136,7 +141,8 @@ async def test_async_client(async_client):
     ):
 
         @async_client.remote_call
-        def sayhi(name: str) -> str: ...
+        def sayhi(name: str) -> str:
+            ...
 
     @async_client.remote_call
     async def yield_data(max_num: int):
@@ -148,7 +154,8 @@ async def test_async_client(async_client):
         index += 1
 
     @async_client.remote_call
-    async def exception() -> str: ...
+    async def exception() -> str:
+        ...
 
     with pytest.raises(RemoteCallError, match="ValueError: Message"):
         await exception()
@@ -164,7 +171,8 @@ async def test_async_client(async_client):
 
 def test_none(sync_client):
     @sync_client.remote_call
-    def none() -> None: ...
+    def none() -> None:
+        ...
 
     assert none() is None
 
@@ -175,7 +183,8 @@ def test_none(sync_client):
 @pytest.mark.asyncio
 async def test_async_none(async_client):
     @async_client.remote_call
-    async def none() -> None: ...
+    async def none() -> None:
+        ...
 
     assert await none() is None
 


### PR DESCRIPTION
**First of all, thank you for this fantastic package. 🙌**

I really like the use of generators and yield statements. I found it extremely innovative, but unfortunately, it didn't work straightaway on my end. So, here I am, excited to contribute and send this fix.

I’m also glad this project builds on top of uvicorn, and comes with OpenAPI documentation—huge pluses all around!

### What's included in this PR:

**1. Fix for broken generators with the latest httpx client**

Closes #27

This addresses an issue where generators using `yield` broke due to changes in `httpx >= 0.24`. Specifically, `aiter_lines` no longer includes line breaks and instead yields empty strings. This case has to be handled in the same logic that previously managed line breaks.

**2. Fix for OpenAPI docs generation when using root return types with Pydantic v2**

Closes #28

Partial support for pydantic v2 is added by detecting the installed version and using the appropriate method for model creation in OpenAPI docs. Since `__root__` is no longer available in `pydantic.create_model` for v2, the code now uses `pydantic.RootModel` when needed.

**3. Test fine-tuning**

I removed unnecessary `sleep` calls from the generator tests. They added significant overhead to the test runtime—tests now complete in under a second. Ideally, tests should avoid `sleep` altogether (or mock time-based behavior) to keep the feedback loop fast during development.

Thanks again for this fantastic package! 🙏

I hope you agree with the changes and find them useful. Looking forward to your feedback and, hopefully, to getting this merged soon!

